### PR TITLE
chore(config): CodeRabbit設定の充実化とCLAUDE.md命名規約追加

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -60,3 +60,8 @@ knowledge_base:
     scope: local
   web_search:
     enabled: true
+  code_guidelines:
+    - path: "CLAUDE.md"
+      instructions: >
+        「コーディング規約」セクションの命名規約（アプリケーション名の表記ルールと
+        ソースコード命名規則）をレビュー基準として適用する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,16 @@ swift package resolve                # SPM 依存解決
 
 ## コーディング規約
 
-### 命名規則
+### 命名規約
+
+#### アプリケーション名
+
+| 用途 | 表記 | 例 |
+|------|------|-----|
+| Display Name（UI表示・App Store） | サブスク君 | アプリ名、ロゴ、OGP |
+| Machine Name（リポジトリ・パッケージ） | subskun | `uechikohei/subskun` |
+
+#### ソースコード命名規則
 
 Swift 標準の命名規則に従う（単体プロジェクトのためプレフィックス不要）:
 


### PR DESCRIPTION
## Summary

CodeRabbit設定を充実化し、CLAUDE.mdをコーディング規約として直接参照させる設定を追加。

## Changes

- `.coderabbit.yaml`: tone_instructions、レイヤー別path_instructions、knowledge_base.code_guidelinesを追加
- `CLAUDE.md`: アプリケーション名の命名規約（サブスク君 / subskun）を追加

## Test plan

- PRを作成してCodeRabbitが日本語でレビューコメントを付けることを確認
- path_instructionsに基づいたレイヤー別の指摘が行われることを確認

## Related issues

- なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coding standards documentation with application naming conventions and source code naming guidelines.

* **Chores**
  * Enhanced code review configuration with structured preferences and automated review settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->